### PR TITLE
Integrate wfg_drive_pat into wfg

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,11 +6,14 @@ TEMPLATED_FILES := design/wfg_stim_sine/rtl/wfg_stim_sine_wishbone_reg.sv \
                    design/wfg_stim_sine/rtl/wfg_stim_sine_top.sv \
                    design/wfg_drive_spi/rtl/wfg_drive_spi_top.sv \
                    design/wfg_drive_spi/rtl/wfg_drive_spi_wishbone_reg.sv \
+                   design/wfg_drive_pat/rtl/wfg_drive_pat_top.sv \
+                   design/wfg_drive_pat/rtl/wfg_drive_pat_wishbone_reg.sv \
                    design/wfg_core/rtl/wfg_core_top.sv \
                    design/wfg_core/rtl/wfg_core_wishbone_reg.sv
 
 DATA_FILES := design/wfg_stim_sine/data/wfg_stim_sine_reg.csv \
               design/wfg_drive_spi/data/wfg_drive_spi_reg.csv \
+              design/wfg_drive_pat/data/wfg_drive_pat_reg.csv \
               design/wfg_core/data/wfg_core_reg.csv
 
 LIBRARIES := $(DATA_FILES:.csv=.json)

--- a/design/wfg_drive_pat/README.md
+++ b/design/wfg_drive_pat/README.md
@@ -1,0 +1,45 @@
+# wfg_drive_pat
+
+The module wfg_drive_pat drives a pattern onto the number of channels specified by the parameter CHANNELS. CHANNELS can range from 1 to 32.
+
+For correct operation it needs to be connected to a wfg_core.
+The signals used are *pat_sync* and *pat_subcycle_cnt*.
+
+The input is received via an axi stream (32 bit) interface. One transaction is performed after each *pat_sync*. The lowest CHANNELS bits are used for transmission, higher bits are discarded.
+
+The fields *begin* and *end* must be set for the channel to work correctly;
+begin can be set to a value of `1` to `subcycles - 1`, while end must be set from `begin+1` to `subcycles`, where `subcycles` is to the number of subcycles at which the core puts out *pat_sync* and in the next cycle resets the count to 0.
+
+Patselect can take values 0-3.
+  - 0 corresponds to *Return to zero (RZ)*
+  - 1 corresponds to *Return to one (RO)*
+  - 2 corresponds to *Non return to one (NRZ)*
+  - 3 corresponds to *Return to complement (RC)*
+
+## Testbench
+
+*WIP*
+
+The module wfg_drive_pat is verified using a testbench written in cocotb and python.
+
+It uses and extends standard components of cocotb.
+
+
+### Testcase generation
+
+Testcases are generated with a `TestFactory`.
+It takes a list of values for each input port and creates a testcase for each of the combinations.
+These values can be fixed to test certain cases, or be set to `None`, in this case they will either be randomized or use a default value.
+
+Input data for the AXI stream is randomly generated for each testcase run.
+
+
+### Output checking
+
+A `OutputMonitor` captures all output values at each clockcycle.
+A `Scoreboard` checks the equivalence of the received values to previously generated expected output.
+
+Expected output is generated at the time the input is randomized. For each clockcycle it is calculated what the corresponding output should be based on the input and the *pat_subcycle_cnt*.
+
+
+

--- a/design/wfg_drive_pat/data/wfg_drive_pat_reg.csv
+++ b/design/wfg_drive_pat/data/wfg_drive_pat_reg.csv
@@ -1,0 +1,22 @@
+Address,RegName,BitName,Access,HW,MSB,LSB,Reset,Description
+4'h0,CTRL,,,,,,,Control register
+,,EN,rw,cfg,31,0,0,Parallel Interface Output enable
+4'h4,CFG,,,,,,,SPI configuration register
+,,BEGIN,rw,cfg,7,0,0,"Select at which subcycle the output occurs, binary encoded"
+,,END,rw,cfg,15,8,0,"Select at which subcycle the transition according to PATSEL occurs, binary encoded"
+4'h8,PATSEL0,,,,,,,Low bit of PATSEL
+,,LOW,rw,cfg,31,0,0,"Select Output Format
+  
+   b00: Return to zero (RZ)
+   b01: Return to one (RO)
+   b10: Non return to one (NRZ)
+   B11: Return to complement (RC)
+"
+4'hC,PATSEL1,,,,,,,High bit of PATSEL
+,,HIGH,rw,cfg,31,0,0,"Select Output Format
+  
+   b00: Return to zero (RZ)
+   b01: Return to one (RO)
+   b10: Non return to one (NRZ)
+   B11: Return to complement (RC)
+"

--- a/design/wfg_drive_pat/data/wfg_drive_pat_reg.json
+++ b/design/wfg_drive_pat/data/wfg_drive_pat_reg.json
@@ -1,0 +1,68 @@
+{
+    "registers": {
+        "CFG": {
+            "address": "4'h4",
+            "description": "SPI configuration register",
+            "entries": {
+                "BEGIN": {
+                    "LSB": "0",
+                    "MSB": "7",
+                    "access": "rw",
+                    "description": "Select at which subcycle the output occurs, binary encoded",
+                    "hardware": "cfg",
+                    "reset": "0"
+                },
+                "END": {
+                    "LSB": "8",
+                    "MSB": "15",
+                    "access": "rw",
+                    "description": "Select at which subcycle the transition according to PATSEL occurs, binary encoded",
+                    "hardware": "cfg",
+                    "reset": "0"
+                }
+            }
+        },
+        "CTRL": {
+            "address": "4'h0",
+            "description": "Control register",
+            "entries": {
+                "EN": {
+                    "LSB": "0",
+                    "MSB": "31",
+                    "access": "rw",
+                    "description": "Parallel Interface Output enable",
+                    "hardware": "cfg",
+                    "reset": "0"
+                }
+            }
+        },
+        "PATSEL0": {
+            "address": "4'h8",
+            "description": "Low bit of PATSEL",
+            "entries": {
+                "LOW": {
+                    "LSB": "0",
+                    "MSB": "31",
+                    "access": "rw",
+                    "description": "Select Output Format\n  \n   b00: Return to zero (RZ)\n   b01: Return to one (RO)\n   b10: Non return to one (NRZ)\n   B11: Return to complement (RC)\n",
+                    "hardware": "cfg",
+                    "reset": "0"
+                }
+            }
+        },
+        "PATSEL1": {
+            "address": "4'hC",
+            "description": "High bit of PATSEL",
+            "entries": {
+                "HIGH": {
+                    "LSB": "0",
+                    "MSB": "31",
+                    "access": "rw",
+                    "description": "Select Output Format\n  \n   b00: Return to zero (RZ)\n   b01: Return to one (RO)\n   b10: Non return to one (NRZ)\n   B11: Return to complement (RC)\n",
+                    "hardware": "cfg",
+                    "reset": "0"
+                }
+            }
+        }
+    }
+}

--- a/design/wfg_drive_pat/rtl/wfg_drive_pat.sv
+++ b/design/wfg_drive_pat/rtl/wfg_drive_pat.sv
@@ -1,0 +1,106 @@
+//                    Copyright Message
+//  --------------------------------------------------------------------------
+//
+//  CONFIDENTIAL and PROPRIETARY
+//  COPYRIGHT (c) semify 2021
+//
+//  All rights are reserved. Reproduction in whole or in part is
+//  prohibited without the written consent of the copyright owner.
+//
+//  ----------------------------------------------------------------------------
+//                    Design Information
+//  ----------------------------------------------------------------------------
+//
+//  Author: Erwin Peterlin
+//
+//  Description : wfg_drive_pat
+//
+
+module wfg_drive_pat #(
+    parameter CHANNELS   = 8,
+    parameter AXIS_WIDTH = 32
+) (
+    input logic clk,   // I; System clock
+    input logic rst_n, // I; Active low reset
+
+    input logic       pat_sync_i,         // I; Start Pulse for one cycle
+    input logic [7:0] pat_subcycle_cnt_i, // I; Current Subcycle
+
+    input logic [    CHANNELS-1:0] ctrl_en_q_i,    // I; Enable signal
+    input logic [(CHANNELS*2)-1:0] patsel_q_i,     // I; Output pattern selector
+    input logic [             7:0] cfg_begin_q_i,  // I; Selects at which subcycle the output begins
+    input logic [             7:0] cfg_end_q_i,    // I; Selects at which subcycle the output ends
+
+    // AXI streaming interface
+    output wire        wfg_axis_tready_o,  // O; ready
+    input  wire        wfg_axis_tvalid_i,  // I; valid
+    input  wire        wfg_axis_tlast_i,   // I; last
+    input  wire [31:0] wfg_axis_tdata_i,   // I; data
+
+    output logic [CHANNELS-1:0] pat_dout_o,    // O; output pins
+    output logic [CHANNELS-1:0] pat_dout_en_o  // O; output enabled
+);
+
+    // -------------------------------------------------------------------------
+    // Definition
+    // -------------------------------------------------------------------------
+
+    assign pat_dout_en_o = ctrl_en_q_i;
+
+    logic [AXIS_WIDTH-1:0] axis_data_next, axis_data_ff;
+    logic axis_ready_next, axis_ready_ff;
+    assign wfg_axis_tready_o = axis_ready_ff;
+
+    // -------------------------------------------------------------------------
+    // Implementation
+    // -------------------------------------------------------------------------
+
+    always_comb begin
+        axis_data_next  = axis_data_ff;
+        axis_ready_next = axis_ready_ff;
+
+        if (pat_sync_i) begin
+            axis_ready_next = '1;
+        end  //if
+
+        if (axis_ready_ff) begin
+            axis_ready_next = '0;
+        end  //if
+
+        if (wfg_axis_tvalid_i) begin
+            axis_data_next = wfg_axis_tdata_i;
+        end
+    end  //always_comb
+
+    genvar k;
+    generate
+        for (k = 0; k < CHANNELS; k++) begin
+            wfg_drive_pat_channel drv (
+                .clk(clk),
+                .rst_n(rst_n),
+                .pat_subcycle_cnt_i(pat_subcycle_cnt_i),
+                .patsel_q_i({patsel_q_i[k+32], patsel_q_i[k]}),
+                .cfg_begin_q_i(cfg_begin_q_i),
+                .cfg_end_q_i(cfg_end_q_i),
+                .ctrl_en_q_i(ctrl_en_q_i[k]),
+                .axis_data_ff(axis_data_ff[k]),
+                .data_o(pat_dout_o[k])
+            );
+        end
+    endgenerate
+
+    // -------------------------------------------------------------------------
+    // ff
+    // -------------------------------------------------------------------------
+
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            axis_data_ff  <= '0;
+            axis_ready_ff <= '0;
+        end else begin
+            axis_data_ff  <= axis_data_next;
+            axis_ready_ff <= axis_ready_next;
+        end
+    end  //always_ff
+endmodule
+

--- a/design/wfg_drive_pat/rtl/wfg_drive_pat_channel.sv
+++ b/design/wfg_drive_pat/rtl/wfg_drive_pat_channel.sv
@@ -1,0 +1,72 @@
+//  CONFIDENTIAL and PROPRIETARY
+//  COPYRIGHT (c) semify 2021
+//
+//  All rights are reserved. Reproduction in whole or in part is
+//  prohibited without the written consent of the copyright owner.
+//
+//  ----------------------------------------------------------------------------
+//                    Design Information
+//  ----------------------------------------------------------------------------
+//
+//  Author: Erwin Peterlin
+//
+//  Description : wfg_drive_pat_channel
+//
+module wfg_drive_pat_channel (
+    input logic clk,   // I; System clock
+    input logic rst_n, // I; Active low reset
+
+    input logic [7:0] pat_subcycle_cnt_i,
+    input logic [1:0] patsel_q_i,
+    input logic [7:0] cfg_begin_q_i,
+    input logic [7:0] cfg_end_q_i,
+    input logic       ctrl_en_q_i,
+    input logic       axis_data_ff,
+
+    output logic data_o
+);
+
+    logic data_next, data_ff;
+    assign data_o = data_ff;
+
+    always_comb begin
+        data_next = data_ff;
+
+        if (pat_subcycle_cnt_i == cfg_begin_q_i) begin
+            data_next = axis_data_ff;
+        end  //if
+
+        if (pat_subcycle_cnt_i == cfg_end_q_i) begin
+            case (patsel_q_i)
+                2'b00: begin
+                    data_next = '0;
+                end  //RZ
+                2'b01: begin
+                    data_next = '1;
+                end  //RO
+                2'b10: begin
+                    data_next = data_ff;
+                end  //NRZ
+                2'b11: begin
+                    if (data_ff == '0 || data_ff == '1) begin
+                        data_next = !data_ff;
+                    end  //if
+                end  //RC
+                //default: $error("invalid pat_select");
+            endcase
+        end  //if
+
+        if (!ctrl_en_q_i) begin
+            data_next = '0;
+        end  //if
+    end  //always_comb
+
+
+    always_ff @(posedge clk or negedge rst_n) begin
+        if (!rst_n) begin
+            data_ff <= '0;
+        end else begin
+            data_ff <= data_next;
+        end
+    end  //always_ff
+endmodule

--- a/design/wfg_drive_pat/rtl/wfg_drive_pat_top.sv
+++ b/design/wfg_drive_pat/rtl/wfg_drive_pat_top.sv
@@ -1,0 +1,106 @@
+// SPDX-FileCopyrightText: © 2022 semify <office@semify-eda.com>
+// SPDX-License-Identifier: Apache-2.0
+
+`default_nettype none
+module wfg_drive_pat_top #(
+    parameter int BUSW = 32,
+    parameter int AXIS_DATA_WIDTH = 32,
+    parameter int CHANNELS = 32
+) (
+    // Wishbone Slave ports
+    input                 wb_clk_i,
+    input                 wb_rst_i,
+    input                 wbs_stb_i,
+    input                 wbs_cyc_i,
+    input                 wbs_we_i,
+    input  [(BUSW/8-1):0] wbs_sel_i,
+    input  [  (BUSW-1):0] wbs_dat_i,
+    input  [  (BUSW-1):0] wbs_adr_i,
+    output                wbs_ack_o,
+    output [  (BUSW-1):0] wbs_dat_o,
+
+    // Core synchronisation interface
+    input wire        wfg_pat_sync_i,         // I; pat_sync pulse
+    input logic [7:0] wfg_pat_subcycle_cnt_i, // I; subcycle_cnt
+
+    // AXI-Stream interface
+    output wire wfg_axis_tready_o,
+    input wire [AXIS_DATA_WIDTH-1:0] wfg_axis_tdata_i,
+    input wire wfg_axis_tlast_i,
+    input wire wfg_axis_tvalid_i,
+
+    output logic [CHANNELS-1:0] pat_dout_o,    // O; output pins
+    output logic [CHANNELS-1:0] pat_dout_en_o  // O; output enabled
+);
+    // Registers
+    //marker_template_start
+    //data: ../data/wfg_drive_pat_reg.json
+    //template: wishbone/instantiate_top.template
+    //marker_template_code
+
+    logic [ 7: 0] cfg_begin_q;             // CFG.BEGIN register output
+    logic [15: 8] cfg_end_q;               // CFG.END register output
+    logic [31: 0] ctrl_en_q;               // CTRL.EN register output
+    logic [31: 0] patsel0_low_q;           // PATSEL0.LOW register output
+    logic [31: 0] patsel1_high_q;          // PATSEL1.HIGH register output
+
+    //marker_template_end
+
+    wfg_drive_pat_wishbone_reg wfg_drive_pat_wishbone_reg (
+        .wb_clk_i (wb_clk_i),
+        .wb_rst_i (wb_rst_i),
+        .wbs_stb_i(wbs_stb_i),
+        .wbs_cyc_i(wbs_cyc_i),
+        .wbs_we_i (wbs_we_i),
+        .wbs_sel_i(wbs_sel_i),
+        .wbs_dat_i(wbs_dat_i),
+        .wbs_adr_i(wbs_adr_i),
+        .wbs_ack_o(wbs_ack_o),
+        .wbs_dat_o(wbs_dat_o),
+
+        //marker_template_start
+        //data: ../data/wfg_drive_pat_reg.json
+        //template: wishbone/assign_to_module.template
+        //marker_template_code
+
+        .cfg_begin_q_o   (cfg_begin_q),    // CFG.BEGIN register output
+        .cfg_end_q_o     (cfg_end_q),      // CFG.END register output
+        .ctrl_en_q_o     (ctrl_en_q),      // CTRL.EN register output
+        .patsel0_low_q_o (patsel0_low_q),  // PATSEL0.LOW register output
+        .patsel1_high_q_o(patsel1_high_q)  // PATSEL1.HIGH register output
+
+        //marker_template_end
+    );
+
+    wfg_drive_pat #(
+        .CHANNELS  (CHANNELS),
+        .AXIS_WIDTH(AXIS_DATA_WIDTH)
+    ) wfg_drive_pat (
+        .clk  (wb_clk_i),  // clock signal
+        .rst_n(!wb_rst_i), // reset signal
+
+        // Core synchronisation interface
+        .pat_sync_i        (wfg_pat_sync_i),
+        .pat_subcycle_cnt_i(wfg_pat_subcycle_cnt_i),
+
+        // AXI streaming interface
+        .wfg_axis_tready_o(wfg_axis_tready_o),  // O; ready
+        .wfg_axis_tvalid_i(wfg_axis_tvalid_i),  // I; valid
+        .wfg_axis_tlast_i (wfg_axis_tlast_i),   // I; last
+        .wfg_axis_tdata_i (wfg_axis_tdata_i),   // I; data
+
+        // Control
+        .ctrl_en_q_i(ctrl_en_q),  // I; pat enable
+
+        // Configuration
+        .cfg_begin_q_i(cfg_begin_q),
+        .cfg_end_q_i  (cfg_end_q),
+        .patsel_q_i   ({patsel1_high_q, patsel0_low_q}),
+
+        // Output
+        .pat_dout_o   (pat_dout_o),
+        .pat_dout_en_o(pat_dout_en_o)
+    );
+
+endmodule
+`default_nettype wire

--- a/design/wfg_drive_pat/rtl/wfg_drive_pat_top.sv_old
+++ b/design/wfg_drive_pat/rtl/wfg_drive_pat_top.sv_old
@@ -1,0 +1,204 @@
+`default_nettype none
+module wfg_drive_pat_top #
+  (
+    parameter integer CHANNELS  = 8,
+    parameter integer C_pat_AXIS_TDATA_WIDTH  = 32
+  )
+  (
+  input       wire         clk               , // I; System clock
+  input       wire         aresetn           , // I; active low reset
+
+  input  wire        wfg_pat_sync_i          , // I; pat_sync pulse
+  input  wire[7:0]   wfg_pat_subcycle_cnt_i  , // I; subcycle_cnt
+  output wire[CHANNELS-1:0] wfg_drive_pat_dout_o    , // O; output pins
+  output wire[CHANNELS-1:0] wfg_drive_pat_dout_en_o , // O; output enabled
+
+  // APB interface signals
+  input       wire         psel_i            , // I; APB select
+  input       wire         penable_i         , // I; APB enable
+  input       wire         pwrite_i          , // I; APB write
+  input       wire  [11:0] paddr_i           , // I; APB address
+  input       wire  [31:0] pwdata_i          , // I; APB write data
+  output      logic        pready_o          , // O; APB ready
+  output      logic [31:0] prdata_o          , // O; APB read data
+  output      logic        pslverr_o         , // O; APB slave error
+
+  // Axi Stream Slave Bus Interface
+  output wire  pat_axis_tready,
+  input wire [C_pat_AXIS_TDATA_WIDTH-1 : 0] pat_axis_tdata,
+  input wire  pat_axis_tlast,
+  input wire  pat_axis_tvalid
+);
+
+  // -------------------------------------------------------------------------
+  // Definition
+  // -------------------------------------------------------------------------
+  import wfg_drive_pat_apb_reg_pkg::*;
+
+  logic [1:0] pprivilege_i;
+  assign pprivilege_i = 2'b11;
+
+  // APB register signals
+  //marker_template_start
+  //[% PROCESS template/general.template%]
+  //[% PROCESS template/apb.template%] [%
+  // SET RegList = data.wfg_reg.data;
+  // INCLUDE apb_reg_inst_signal;
+  // %]
+  //marker_template_code
+  // Based on RegList version 0.1 from 23. Aug 2021
+  logic         cfg_00_en_q                        ; // CFG_00.EN register output
+  logic [  2:1] cfg_00_patsel_q                    ; // CFG_00.PATSEL register output
+  logic [ 15:8] cfg_00_begin_q                     ; // CFG_00.BEGIN register output
+  logic [23:16] cfg_00_end_q                       ; // CFG_00.END register output
+  logic         cfg_01_en_q                        ; // CFG_01.EN register output
+  logic [  2:1] cfg_01_patsel_q                    ; // CFG_01.PATSEL register output
+  logic [ 15:8] cfg_01_begin_q                     ; // CFG_01.BEGIN register output
+  logic [23:16] cfg_01_end_q                       ; // CFG_01.END register output
+  logic         cfg_02_en_q                        ; // CFG_02.EN register output
+  logic [  2:1] cfg_02_patsel_q                    ; // CFG_02.PATSEL register output
+  logic [ 15:8] cfg_02_begin_q                     ; // CFG_02.BEGIN register output
+  logic [23:16] cfg_02_end_q                       ; // CFG_02.END register output
+  logic         cfg_03_en_q                        ; // CFG_03.EN register output
+  logic [  2:1] cfg_03_patsel_q                    ; // CFG_03.PATSEL register output
+  logic [ 15:8] cfg_03_begin_q                     ; // CFG_03.BEGIN register output
+  logic [23:16] cfg_03_end_q                       ; // CFG_03.END register output
+  logic         cfg_04_en_q                        ; // CFG_04.EN register output
+  logic [  2:1] cfg_04_patsel_q                    ; // CFG_04.PATSEL register output
+  logic [ 15:8] cfg_04_begin_q                     ; // CFG_04.BEGIN register output
+  logic [23:16] cfg_04_end_q                       ; // CFG_04.END register output
+  logic         cfg_05_en_q                        ; // CFG_05.EN register output
+  logic [  2:1] cfg_05_patsel_q                    ; // CFG_05.PATSEL register output
+  logic [ 15:8] cfg_05_begin_q                     ; // CFG_05.BEGIN register output
+  logic [23:16] cfg_05_end_q                       ; // CFG_05.END register output
+  logic         cfg_06_en_q                        ; // CFG_06.EN register output
+  logic [  2:1] cfg_06_patsel_q                    ; // CFG_06.PATSEL register output
+  logic [ 15:8] cfg_06_begin_q                     ; // CFG_06.BEGIN register output
+  logic [23:16] cfg_06_end_q                       ; // CFG_06.END register output
+  logic         cfg_07_en_q                        ; // CFG_07.EN register output
+  logic [  2:1] cfg_07_patsel_q                    ; // CFG_07.PATSEL register output
+  logic [ 15:8] cfg_07_begin_q                     ; // CFG_07.BEGIN register output
+  logic [23:16] cfg_07_end_q                       ; // CFG_07.END register output
+  logic         test_en_q                          ; // TEST.EN register output
+  logic [ 17:0] reginfo_date_d                     ; // REGINFO.DATE register input
+  logic [  7:0] id_peripheral_type_d               ; // ID.PERIPHERAL_TYPE register input
+  logic [ 15:8] id_version_d                       ; // ID.VERSION register input
+//marker_template_end
+
+
+  logic[CHANNELS-1:0] en_i;
+  logic[CHANNELS-1:0][1:0] pat_select_i;
+  logic[CHANNELS-1:0][7:0] out_begin_i;
+  logic[CHANNELS-1:0][7:0] out_end_i;
+
+  //marker_template_start
+  //[% PROCESS template/general.template%]
+  //[% PROCESS template/wfg.template%] [%
+  // SET RegList = data.wfg_reg.data;
+  // INCLUDE wfg_concat_to_multilevel_arrays;
+  // %]
+  //marker_template_code
+
+  assign en_i = {cfg_07_en_q, cfg_06_en_q, cfg_05_en_q, cfg_04_en_q, cfg_03_en_q, cfg_02_en_q, cfg_01_en_q, cfg_00_en_q};
+  assign pat_select_i = {cfg_07_patsel_q, cfg_06_patsel_q, cfg_05_patsel_q, cfg_04_patsel_q, cfg_03_patsel_q, cfg_02_patsel_q, cfg_01_patsel_q, cfg_00_patsel_q};
+  assign out_begin_i = {cfg_07_begin_q, cfg_06_begin_q, cfg_05_begin_q, cfg_04_begin_q, cfg_03_begin_q, cfg_02_begin_q, cfg_01_begin_q, cfg_00_begin_q};
+  assign out_end_i = {cfg_07_end_q, cfg_06_end_q, cfg_05_end_q, cfg_04_end_q, cfg_03_end_q, cfg_02_end_q, cfg_01_end_q, cfg_00_end_q};
+//marker_template_end
+
+  // Based on RegList version 0.1 from 18. Aug 2021
+  // -------------------------------------------------------------------------
+  // Implementation
+  // -------------------------------------------------------------------------
+
+  wfg_drive_pat # (
+    .CHANNELS(CHANNELS),
+    .AXIS_WIDTH(C_pat_AXIS_TDATA_WIDTH)
+  ) wfg_drive_pat_inst (
+    .clk                    (clk),
+    .rst_n                  (aresetn),
+    .pat_sync_i             (wfg_pat_sync_i),
+    .pat_subcycle_cnt_i     (wfg_pat_subcycle_cnt_i),
+    .en_i                   (en_i),
+    .pat_select_i           (pat_select_i),
+    .out_begin_i            (out_begin_i),
+    .out_end_i              (out_end_i),
+    .wfg_drive_pat_tready_o (pat_axis_tready),
+    .wfg_drive_pat_tvalid_i (pat_axis_tvalid),
+    .wfg_drive_pat_tlast_i  (pat_axis_tlast),
+    .wfg_drive_pat_tdata_i  (pat_axis_tdata),
+    .pat_dout_o             (wfg_drive_pat_dout_o),
+    .pat_dout_en_o          (wfg_drive_pat_dout_en_o)
+  );
+
+
+  wfg_drive_pat_apb_reg apb_reg (
+    .clk                       (clk     ) , // System clock
+    .aresetn                   (aresetn ) , // active low reset
+
+    //marker_template_start
+    //[% PROCESS template/general.template%]
+    //[% PROCESS template/apb.template%] [%
+    // SET RegList = data.wfg_reg.data;
+    // INCLUDE apb_reg_inst_inst;
+    // %]
+    //marker_template_code
+    // Based on RegList version 0.1 from 23. Aug 2021
+    .cfg_00_en_q_o                       (cfg_00_en_q                        ), // O; CFG_00.EN register output
+    .cfg_00_patsel_q_o                   (cfg_00_patsel_q                    ), // O; CFG_00.PATSEL register output
+    .cfg_00_begin_q_o                    (cfg_00_begin_q                     ), // O; CFG_00.BEGIN register output
+    .cfg_00_end_q_o                      (cfg_00_end_q                       ), // O; CFG_00.END register output
+    .cfg_01_en_q_o                       (cfg_01_en_q                        ), // O; CFG_01.EN register output
+    .cfg_01_patsel_q_o                   (cfg_01_patsel_q                    ), // O; CFG_01.PATSEL register output
+    .cfg_01_begin_q_o                    (cfg_01_begin_q                     ), // O; CFG_01.BEGIN register output
+    .cfg_01_end_q_o                      (cfg_01_end_q                       ), // O; CFG_01.END register output
+    .cfg_02_en_q_o                       (cfg_02_en_q                        ), // O; CFG_02.EN register output
+    .cfg_02_patsel_q_o                   (cfg_02_patsel_q                    ), // O; CFG_02.PATSEL register output
+    .cfg_02_begin_q_o                    (cfg_02_begin_q                     ), // O; CFG_02.BEGIN register output
+    .cfg_02_end_q_o                      (cfg_02_end_q                       ), // O; CFG_02.END register output
+    .cfg_03_en_q_o                       (cfg_03_en_q                        ), // O; CFG_03.EN register output
+    .cfg_03_patsel_q_o                   (cfg_03_patsel_q                    ), // O; CFG_03.PATSEL register output
+    .cfg_03_begin_q_o                    (cfg_03_begin_q                     ), // O; CFG_03.BEGIN register output
+    .cfg_03_end_q_o                      (cfg_03_end_q                       ), // O; CFG_03.END register output
+    .cfg_04_en_q_o                       (cfg_04_en_q                        ), // O; CFG_04.EN register output
+    .cfg_04_patsel_q_o                   (cfg_04_patsel_q                    ), // O; CFG_04.PATSEL register output
+    .cfg_04_begin_q_o                    (cfg_04_begin_q                     ), // O; CFG_04.BEGIN register output
+    .cfg_04_end_q_o                      (cfg_04_end_q                       ), // O; CFG_04.END register output
+    .cfg_05_en_q_o                       (cfg_05_en_q                        ), // O; CFG_05.EN register output
+    .cfg_05_patsel_q_o                   (cfg_05_patsel_q                    ), // O; CFG_05.PATSEL register output
+    .cfg_05_begin_q_o                    (cfg_05_begin_q                     ), // O; CFG_05.BEGIN register output
+    .cfg_05_end_q_o                      (cfg_05_end_q                       ), // O; CFG_05.END register output
+    .cfg_06_en_q_o                       (cfg_06_en_q                        ), // O; CFG_06.EN register output
+    .cfg_06_patsel_q_o                   (cfg_06_patsel_q                    ), // O; CFG_06.PATSEL register output
+    .cfg_06_begin_q_o                    (cfg_06_begin_q                     ), // O; CFG_06.BEGIN register output
+    .cfg_06_end_q_o                      (cfg_06_end_q                       ), // O; CFG_06.END register output
+    .cfg_07_en_q_o                       (cfg_07_en_q                        ), // O; CFG_07.EN register output
+    .cfg_07_patsel_q_o                   (cfg_07_patsel_q                    ), // O; CFG_07.PATSEL register output
+    .cfg_07_begin_q_o                    (cfg_07_begin_q                     ), // O; CFG_07.BEGIN register output
+    .cfg_07_end_q_o                      (cfg_07_end_q                       ), // O; CFG_07.END register output
+    .test_en_q_o                         (test_en_q                          ), // O; TEST.EN register output
+    .reginfo_date_d_i                    (reginfo_date_d                     ), // I; REGINFO.DATE register input
+    .id_peripheral_type_d_i              (id_peripheral_type_d               ), // I; ID.PERIPHERAL_TYPE register input
+    .id_version_d_i                      (id_version_d                       ), // I; ID.VERSION register input
+//marker_template_end
+    // APB interface signals
+    .presetn_i                 (aresetn     ), // APB interface domain reset
+    .psel_i                    (psel_i      ), // APB select
+    .penable_i                 (penable_i   ), // APB enable
+    .pwrite_i                  (pwrite_i    ), // APB write
+    .paddr_i                   (paddr_i     ), // APB address
+    .pwdata_i                  (pwdata_i    ), // APB write data
+    .pready_o                  (pready_o    ), // APB ready
+    .prdata_o                  (prdata_o    ), // APB read data
+    .pslverr_o                 (pslverr_o   ), // APB slave error
+    .pprivilege_i              (pprivilege_i) // APB privilege mode 0 - low, 3 - high
+  );
+
+
+  // Register handling --------------------------------------------------------
+  // constants
+  assign id_peripheral_type_d = ID_PERIPHERAL_TYPE_RESET;
+  assign id_version_d         = ID_VERSION_RESET;
+  assign reginfo_date_d       = REGINFO_DATE_RESET;
+
+endmodule
+`default_nettype wire

--- a/design/wfg_drive_pat/rtl/wfg_drive_pat_wishbone_reg.sv
+++ b/design/wfg_drive_pat/rtl/wfg_drive_pat_wishbone_reg.sv
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: © 2022 semify <office@semify-eda.com>
+// SPDX-License-Identifier: Apache-2.0
+
+`default_nettype none
+module wfg_drive_pat_wishbone_reg #(
+    parameter int BUSW = 32
+) (
+    // Wishbone Slave ports
+    input                       wb_clk_i,
+    input                       wb_rst_i,
+    input                       wbs_stb_i,
+    input                       wbs_cyc_i,
+    input                       wbs_we_i,
+    input        [(BUSW/8-1):0] wbs_sel_i,
+    input        [  (BUSW-1):0] wbs_dat_i,
+    input        [  (BUSW-1):0] wbs_adr_i,
+    output logic                wbs_ack_o,
+    output logic [  (BUSW-1):0] wbs_dat_o,
+
+    // Registers
+    //marker_template_start
+    //data: ../data/wfg_drive_pat_reg.json
+    //template: wishbone/register_interface.template
+    //marker_template_code
+
+    output logic [ 7:0] cfg_begin_q_o,    // CFG.BEGIN register output
+    output logic [15:8] cfg_end_q_o,      // CFG.END register output
+    output logic [31:0] ctrl_en_q_o,      // CTRL.EN register output
+    output logic [31:0] patsel0_low_q_o,  // PATSEL0.LOW register output
+    output logic [31:0] patsel1_high_q_o  // PATSEL1.HIGH register output
+
+    //marker_template_end
+);
+
+    //marker_template_start
+    //data: ../data/wfg_drive_pat_reg.json
+    //template: wishbone/instantiate_registers.template
+    //marker_template_code
+
+    logic [ 7: 0] cfg_begin_ff;            // CFG.BEGIN FF
+    logic [15: 8] cfg_end_ff;              // CFG.END FF
+    logic [31: 0] ctrl_en_ff;              // CTRL.EN FF
+    logic [31: 0] patsel0_low_ff;          // PATSEL0.LOW FF
+    logic [31: 0] patsel1_high_ff;         // PATSEL1.HIGH FF
+
+    //marker_template_end
+
+    // Wishbone write to slave
+    always_ff @(posedge wb_clk_i) begin
+        if (wb_rst_i) begin
+            //marker_template_start
+            //data: ../data/wfg_drive_pat_reg.json
+            //template: wishbone/reset_registers.template
+            //marker_template_code
+
+            cfg_begin_ff    <= 0;
+            cfg_end_ff      <= 0;
+            ctrl_en_ff      <= 0;
+            patsel0_low_ff  <= 0;
+            patsel1_high_ff <= 0;
+
+            //marker_template_end
+        end else if (wbs_stb_i && wbs_we_i && wbs_cyc_i) begin
+            case (wbs_adr_i)
+                //marker_template_start
+                //data: ../data/wfg_drive_pat_reg.json
+                //template: wishbone/assign_to_registers.template
+                //marker_template_code
+
+                4'h4: begin
+                    cfg_begin_ff <= wbs_dat_i[7:0];
+                    cfg_end_ff   <= wbs_dat_i[15:8];
+                end
+                4'h0:       ctrl_en_ff               <= wbs_dat_i[31: 0];
+                4'h8:       patsel0_low_ff           <= wbs_dat_i[31: 0];
+                4'hC:       patsel1_high_ff          <= wbs_dat_i[31: 0];
+
+                //marker_template_end
+                default: begin
+                end
+            endcase
+        end
+    end
+
+    // Wishbone read from slave
+    always_ff @(posedge wb_clk_i) begin
+        if (wb_rst_i) begin
+            wbs_dat_o <= '0;
+        end else begin
+            if (wbs_stb_i && !wbs_we_i && wbs_cyc_i) begin
+                wbs_dat_o <= '0;  // default value
+                case (wbs_adr_i)
+                    //marker_template_start
+                    //data: ../data/wfg_drive_pat_reg.json
+                    //template: wishbone/assign_from_registers.template
+                    //marker_template_code
+
+                    4'h4: begin
+                        wbs_dat_o[7:0]  <= cfg_begin_ff;
+                        wbs_dat_o[15:8] <= cfg_end_ff;
+                    end
+                    4'h0:       wbs_dat_o[31: 0] <= ctrl_en_ff;
+                    4'h8:       wbs_dat_o[31: 0] <= patsel0_low_ff;
+                    4'hC:       wbs_dat_o[31: 0] <= patsel1_high_ff;
+
+                    //marker_template_end
+                    default:    wbs_dat_o <= 'X;
+                endcase
+            end
+        end
+    end
+
+    // Acknowledgement
+    always_ff @(posedge wb_clk_i) begin
+        if (wb_rst_i) wbs_ack_o <= 1'b0;
+        else wbs_ack_o <= wbs_stb_i && wbs_cyc_i & !wbs_ack_o;
+    end
+
+    //marker_template_start
+    //data: ../data/wfg_drive_pat_reg.json
+    //template: wishbone/assign_outputs.template
+    //marker_template_code
+
+    assign cfg_begin_q_o    = cfg_begin_ff;
+    assign cfg_end_q_o      = cfg_end_ff;
+    assign ctrl_en_q_o      = ctrl_en_ff;
+    assign patsel0_low_q_o  = patsel0_low_ff;
+    assign patsel1_high_q_o = patsel1_high_ff;
+
+    //marker_template_end
+endmodule
+`default_nettype wire

--- a/design/wfg_drive_pat/sim/Makefile
+++ b/design/wfg_drive_pat/sim/Makefile
@@ -1,0 +1,19 @@
+# source files
+SRC := $(wildcard ../rtl/*.sv)
+SRC += $(wildcard ../testbench/*.sv)
+
+# defaults
+SIM ?= icarus
+TOPLEVEL_LANG ?= verilog
+
+VERILOG_SOURCES += $(SRC)
+
+# TOPLEVEL is the name of the toplevel module in your Verilog or VHDL file
+TOPLEVEL = wfg_drive_pat_tb
+
+# MODULE is the basename of the Python test file
+export PYTHONPATH := $(PYTHONPATH):../testbench/
+MODULE = test_wfg_drive_pat
+
+# include cocotb's make rules to take care of the simulator setup
+include $(shell cocotb-config --makefiles)/Makefile.sim

--- a/design/wfg_drive_pat/testbench/test_wfg_drive_pat.py
+++ b/design/wfg_drive_pat/testbench/test_wfg_drive_pat.py
@@ -1,0 +1,273 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import os
+import random
+import cocotb
+import pdb
+from cocotb.clock import Clock
+from cocotb.triggers import ClockCycles
+from cocotbext.wishbone.driver import WishboneMaster, WBOp
+from cocotbext.axi import AxiStreamBus, AxiStreamSource
+from cocotb.triggers import RisingEdge, FallingEdge
+from cocotb_bus.monitors import Monitor
+from cocotb_bus.scoreboard import Scoreboard
+from cocotb.regression import TestFactory
+
+ADDITIONAL_OUTPUT = False
+
+CHANNELS = 32
+SUBCYCLES_PER_SYNC = 24
+
+class OutputMonitor(Monitor):
+    def __init__(self, dut, name="",callback=None, event=None):
+        self.dut = dut
+        self.name = name
+        Monitor.__init__(self, callback, event)
+
+    async def _monitor_recv(self):
+        clkedge = RisingEdge(self.dut.io_wbs_clk)
+        while True:
+            await clkedge
+            output = self.dut.wfg_drive_pat_dout_o.value
+            self._recv(str(output))
+#========
+
+"""
+async def drive_sync(dut):
+    dut.wfg_wfg_pat_sync_i.value = 0
+    sync_cnt = 0
+    while True:
+        await RisingEdge(dut.io_wbs_clk)
+        if sync_cnt == CLK_PER_SYNC-1:
+            sync_cnt = 0
+            dut.wfg_wfg_pat_sync_i.value = 1
+        else:
+            sync_cnt = sync_cnt + 1
+            dut.wfg_wfg_pat_sync_i.value = 0
+"""
+
+async def reset(dut):
+    await ClockCycles(dut.io_wbs_clk, 1)
+    dut.io_wbs_rst.value = 1
+    await ClockCycles(dut.io_wbs_clk, 1)
+    dut.io_wbs_rst.value = 0
+    await ClockCycles(dut.io_wbs_clk, 1)
+
+async def set_register(dut, wbs, address, data):
+    dut._log.info(f"Set register {address} : {data}")
+
+    wbRes = await wbs.send_cycle([WBOp(address, data)])
+    
+    rvalues = [wb.datrd for wb in wbRes]
+    dut._log.info(f"Returned values : {rvalues}")
+
+async def configure(dut, wbs, en, pat, begin, end): # TODO
+    #begin = 9
+    #end = 16
+
+    #en = 7
+    #pat = [1,2]
+    #pat[0] = 3
+    #pat[1] = 1
+
+    await set_register(dut, wbs, 0x4, (begin & 0xFF) | ((end & 0xFF)<<8))
+    await set_register(dut, wbs, 0x8, pat[0])
+    await set_register(dut, wbs, 0xC, pat[1])
+    await set_register(dut, wbs, 0x0, en) # Enable PAT
+
+class MyScoreboard(Scoreboard):
+    def compare(self, got, exp, log, **_):
+        if got != exp and exp != 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx':
+            self.errors += 1
+            #log.error("Received transaction differed from expected output.")
+            log.warning("Received transaction differed from expected output.")
+            log.warning("Expected: {0!s}.\nReceived: {1!s}.".format(exp, got))
+            #if self._imm:
+            #  raise TestFailure("Received transaction differed from expected transaction.")
+        elif ADDITIONAL_OUTPUT:
+            log.info("Received transaction matches expected output.")
+            log.info("Expected: {0!s}.\nReceived: {1!s}.".format(exp, got))
+#========
+
+class Testbench(object):
+    def __init__(self, dut):
+        self.dut = dut
+        self.dut._log.info("Init TB...")
+
+        clock = Clock(dut.io_wbs_clk, 10, units="ns")  # Create a 10ns period clock on port clk
+        cocotb.fork(clock.start())  # Start the clock
+        cocotb.fork(self.drive_subcycles())  # count subcycles
+
+    async def drive_subcycles(self):
+        self.dut.wgf_pat_subcycle_cnt_i.value = 0
+        self.dut.wfg_pat_sync_i.value = 1
+        while True:
+            await RisingEdge(self.dut.io_wbs_clk)
+            subcycles = self.dut.wgf_pat_subcycle_cnt_i.value
+            if subcycles == SUBCYCLES_PER_SYNC-2:
+                self.dut.wgf_pat_subcycle_cnt_i.value = subcycles + 1
+                self.dut.wfg_pat_sync_i.value = 1
+            elif subcycles == SUBCYCLES_PER_SYNC-1:
+                self.dut.wgf_pat_subcycle_cnt_i.value = 0
+                self.dut.wfg_pat_sync_i.value = 0
+            else:
+                self.dut.wgf_pat_subcycle_cnt_i.value = subcycles + 1
+                self.dut.wfg_pat_sync_i.value = 0
+#========
+
+def make_expected_output(dut, input, out_begin, out_end, pat_select_i, en_i):
+    expected_output = []
+
+    print(input)
+
+    byte = bin(input)[2:].rjust(CHANNELS, '0')[::-1]
+
+    print("byte")
+    print(byte)
+    print("en")
+    print(bin(en_i))    
+    
+    for i in range(SUBCYCLES_PER_SYNC):
+
+        next_output = ''
+        for j in range(CHANNELS):
+            pat_select = (pat_select_i[0]>>j & 1) | ((pat_select_i[1]>>j & 1)<<1)
+            en         = (en_i>>j) & 1
+            bit        = str((input>>j) & 1)
+            
+            print("i={}, j={}, en={}, pat={}, bit={}".format(i, j, en, pat_select, bit))
+
+            if en == 0:
+                next_output = 'z' + next_output
+            elif pat_select == 0: # RZ
+                if i >= out_end:
+                    next_output = '0' + next_output
+                elif i >= out_begin:
+                    next_output = bit + next_output
+                else:
+                    next_output = '0' + next_output
+            elif pat_select == 1: # RO
+                if i >= out_end:
+                    next_output = '1' + next_output
+                elif i >= out_begin:
+                    next_output = bit + next_output
+                else:
+                    next_output = '0' + next_output
+            elif pat_select == 2: # NRZ
+                if i >= out_end:
+                    next_output = bit + next_output
+                elif i >= out_begin:
+                    next_output = bit + next_output
+                else:
+                    next_output = '0' + next_output
+            elif pat_select == 3: # RC
+                if i >= out_end:
+                    if bit == '0':
+                        next_output = '1' + next_output
+                    else:
+                        next_output = '0' + next_output
+                elif i >= out_begin:
+                    next_output = bit + next_output
+                else:
+                    next_output = '0' + next_output
+            else:
+                dut._log.error('should not happen!')
+                
+            print(next_output)
+
+        expected_output.append(''.join(next_output))
+    
+    print()
+    
+    for j in reversed(range(CHANNELS)):
+        pat_select = (pat_select_i[0]>>j & 1) | ((pat_select_i[1]>>j & 1)<<1)
+        print(pat_select, end="")
+    print("")
+    
+    print(byte)
+    
+    for exp in expected_output:
+        print(exp)
+    
+    return expected_output
+    
+@cocotb.coroutine
+async def run_test(dut, en=None, pat=None, begin=None, end=None, inputlen=None):
+
+    if en == None:
+        en = random.randint(0, 2**(CHANNELS-1))
+    if pat == None:
+        pat = [random.randint(0, 2**(CHANNELS-1)), random.randint(0, 2**(CHANNELS-1))]
+    if begin == None:
+        begin = 0x08 # int.from_bytes(b'\x08\x08\x08\x08\x08\x08\x08\x09', byteorder='big')
+    if end == None:
+        end = 0x10 # int.from_bytes(b'\x10\x10\x10\x10\x10\x10\x10\x10', byteorder='big')
+    if inputlen == None:
+        inputlen = random.randint(1, 20)
+
+    tb = Testbench(dut)
+
+    input = [random.randint(0, 2**(CHANNELS-1)) for _ in range(inputlen)]
+    print(input)
+    
+    for byte in input:
+        expected_output = make_expected_output(dut, input=byte, out_begin=begin, out_end=end, pat_select_i=pat, en_i=en)
+
+        await reset(dut)
+        
+        # Wishbone Master
+        wbs = WishboneMaster(dut, "io_wbs", dut.io_wbs_clk,
+                                      width=32,   # size of data bus
+                                      timeout=10) # in clock cycle number
+
+        await configure(dut, wbs, en=en, pat=pat, begin=begin, end=end)
+
+        await FallingEdge(dut.wfg_pat_sync_i) # TODO
+        
+        output_mon = OutputMonitor(dut)
+        
+        scoreboard = MyScoreboard(dut)
+        scoreboard.add_interface(output_mon, expected_output)
+
+        print("Sending data")
+    
+        axis_source = AxiStreamSource(AxiStreamBus.from_prefix(dut, "wfg_axis"), dut.io_wbs_clk, dut.io_wbs_rst)
+        for byte in input:
+            await axis_source.send([byte])
+            
+        await axis_source.send([0xFF])
+        await axis_source.send([0xFF])
+
+        print("Waiting for expected_output != []")
+
+        while expected_output != []:
+            print(expected_output)
+            await ClockCycles(dut.io_wbs_clk, 1)
+
+        output_mon.kill()
+
+        print("Result")
+
+        raise scoreboard.result
+
+
+factory = TestFactory(run_test)
+factory.add_option("en", [None])
+
+#pat = [None] + [sum(j * 2**i for i in range(0, 15, 2)) for j in range (0, 4)]
+pat = [None]
+factory.add_option("pat", pat)
+
+#begin = [None, int.from_bytes(b'\x01\x01\x01\x01\x01\x01\x01\x01', byteorder='big')]
+begin = [None]
+
+factory.add_option("begin", begin)
+
+end = [None]
+factory.add_option("end", end)
+
+inputlen = [None, 1]
+factory.add_option("inputlen", inputlen)
+
+factory.generate_tests()

--- a/design/wfg_drive_pat/testbench/wfg_drive_pat_tb.sv
+++ b/design/wfg_drive_pat/testbench/wfg_drive_pat_tb.sv
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: © 2022 semify <office@semify-eda.com>
+// SPDX-License-Identifier: Apache-2.0
+
+`timescale 1ns / 1ps
+
+`ifdef VERILATOR  // make parameter readable from VPI
+`define VL_RD /*verilator public_flat_rd*/
+`else
+`define VL_RD
+`endif
+
+module wfg_drive_pat_tb #(
+    parameter int BUSW = 32,
+    parameter int AXIS_DATA_WIDTH = 32,
+    parameter int CHANNELS = 32
+) (
+    // Wishbone interface signals
+    input               io_wbs_clk,
+    input               io_wbs_rst,
+    input  [(BUSW-1):0] io_wbs_adr,
+    input  [(BUSW-1):0] io_wbs_datwr,
+    output [(BUSW-1):0] io_wbs_datrd,
+    input               io_wbs_we,
+    input               io_wbs_stb,
+    output              io_wbs_ack,
+    input               io_wbs_cyc,
+
+    // Core synchronisation interface
+    input logic wfg_pat_sync_i,
+    input logic [7:0] wgf_pat_subcycle_cnt_i,
+
+    // AXI-Stream interface
+    output wire                        wfg_axis_tready,  // O; ready
+    input  logic                       wfg_axis_tvalid,  // I; valid
+    input  logic                       wfg_axis_tlast,   // I; last
+    input  logic [AXIS_DATA_WIDTH-1:0] wfg_axis_tdata,   // I; data
+
+    // pat IO interface
+    output wire [CHANNELS-1:0] wfg_drive_pat_dout_o,    // O; output pins
+    output wire [CHANNELS-1:0] wfg_drive_pat_dout_en_o  // O; output enabled
+);
+
+    wfg_drive_pat_top #(
+        .BUSW(BUSW),
+        .CHANNELS(CHANNELS),
+        .AXIS_DATA_WIDTH(AXIS_DATA_WIDTH)
+    ) wfg_drive_pat_top (
+        .wb_clk_i (io_wbs_clk),
+        .wb_rst_i (io_wbs_rst),
+        .wbs_stb_i(io_wbs_stb),
+        .wbs_cyc_i(io_wbs_cyc),
+        .wbs_we_i (io_wbs_we),
+        .wbs_sel_i(4'b1111),
+        .wbs_dat_i(io_wbs_datwr),
+        .wbs_adr_i(io_wbs_adr),
+        .wbs_ack_o(io_wbs_ack),
+        .wbs_dat_o(io_wbs_datrd),
+
+        .wfg_pat_sync_i(wfg_pat_sync_i),
+        .wfg_pat_subcycle_cnt_i(wgf_pat_subcycle_cnt_i),
+
+        .wfg_axis_tready_o(wfg_axis_tready),
+        .wfg_axis_tdata_i (wfg_axis_tdata),
+        .wfg_axis_tlast_i (wfg_axis_tlast),
+        .wfg_axis_tvalid_i(wfg_axis_tvalid),
+
+        .pat_dout_o(wfg_drive_pat_dout_o),
+        .pat_dout_en_o(wfg_drive_pat_dout_en_o)
+    );
+
+    // Dump waves
+`ifndef VERILATOR
+    initial begin
+        $dumpfile("wfg_drive_pat_tb.vcd");
+        $dumpvars(0, wfg_drive_pat_tb);
+    end
+`endif
+
+endmodule

--- a/design/wfg_drive_spi/testbench/test_wfg_drive_spi.py
+++ b/design/wfg_drive_spi/testbench/test_wfg_drive_spi.py
@@ -6,8 +6,7 @@ import cocotb
 from cocotb.clock import Clock
 from cocotb.regression import TestFactory
 from cocotb.triggers import Timer, RisingEdge, FallingEdge
-from cocotbext.wishbone.driver import WishboneMaster
-from cocotbext.wishbone.driver import WBOp
+from cocotbext.wishbone.driver import WishboneMaster, WBOp
 from cocotbext.axi import AxiStreamBus, AxiStreamSource
 from cocotbext.spi import SpiMaster, SpiSignals, SpiConfig, SpiSlaveBase
 #from random import randbytes # Possible in Python 3.9+

--- a/design/wfg_top/rtl/wfg_top.sv
+++ b/design/wfg_top/rtl/wfg_top.sv
@@ -6,19 +6,19 @@ module wfg_top #(
     parameter int BUSW = 32
 ) (
     // Wishbone interface signals
-    input                     io_wbs_clk,
-    input                     io_wbs_rst,
-    input        [(BUSW-1):0] io_wbs_adr,
-    input        [(BUSW-1):0] io_wbs_datwr,
-    output       [(BUSW-1):0] io_wbs_datrd,
-    input                     io_wbs_we,
-    input                     io_wbs_stb,
-    output                    io_wbs_ack,
-    input                     io_wbs_cyc,
+    input               io_wbs_clk,
+    input               io_wbs_rst,
+    input  [(BUSW-1):0] io_wbs_adr,
+    input  [(BUSW-1):0] io_wbs_datwr,
+    output [(BUSW-1):0] io_wbs_datrd,
+    input               io_wbs_we,
+    input               io_wbs_stb,
+    output              io_wbs_ack,
+    input               io_wbs_cyc,
 
-    output       wfg_drive_spi_sclk_o,
-    output       wfg_drive_spi_cs_no,
-    output       wfg_drive_spi_sdo_o
+    output wfg_drive_spi_sclk_o,
+    output wfg_drive_spi_cs_no,
+    output wfg_drive_spi_sdo_o
 );
     // Wishbone interconnect
 
@@ -76,7 +76,7 @@ module wfg_top #(
                 my_io_wbs_datrd = 'x;
         endcase
     end
-    
+
     assign io_wbs_datrd = my_io_wbs_datrd;
 
     // Core synchronisation interface


### PR DESCRIPTION
This PR adds a new driver, wfg_drive_pat, used to drive values with:

  - *Return to zero (RZ)*
  - *Return to one (RO)*
  - *Non return to one (NRZ)*
  - *Return to complement (RC)*